### PR TITLE
Adiciona schemas GraphQL para demais modelos

### DIFF
--- a/graphql/announcement.graphql
+++ b/graphql/announcement.graphql
@@ -1,0 +1,52 @@
+"Announcement about offers or updates."
+type Announcement @model(class: "App\\Models\\Api\\V1\\Announcement") {
+  id: ID!
+  title: String!
+  subtitle: String
+  message: String
+  button_text: String
+  button_url: String
+  note: String
+  order: Int
+  status: Boolean!
+  photo_path: String
+  created_at: DateTimeTz!
+  updated_at: DateTimeTz!
+}
+
+extend type Query {
+  announcement(id: ID! @eq): Announcement @find
+  announcements(page: Int, status: Boolean): [Announcement!]!
+    @paginate(defaultCount: 10)
+}
+
+extend type Mutation {
+  createAnnouncement(input: CreateAnnouncementInput! @spread): Announcement! @create(model: "App\\Models\\Api\\V1\\Announcement")
+  updateAnnouncement(input: UpdateAnnouncementInput! @spread): Announcement! @update(model: "App\\Models\\Api\\V1\\Announcement")
+  deleteAnnouncement(id: ID! @whereKey): Announcement! @delete(model: "App\\Models\\Api\\V1\\Announcement")
+}
+
+input CreateAnnouncementInput {
+  title: String!
+  subtitle: String
+  message: String
+  button_text: String
+  button_url: String
+  note: String
+  order: Int
+  status: Boolean = true
+  photo_path: String
+}
+
+input UpdateAnnouncementInput {
+  id: ID! @whereKey
+  title: String
+  subtitle: String
+  message: String
+  button_text: String
+  button_url: String
+  note: String
+  order: Int
+  status: Boolean
+  photo_path: String
+}

--- a/graphql/cardflag.graphql
+++ b/graphql/cardflag.graphql
@@ -1,0 +1,61 @@
+"Credit card brand information."
+type CardFlag @model(class: "App\\Models\\Api\\V1\\CardFlag") {
+  id: ID!
+  name: String!
+  photo_path: String
+  cardFlagInstallmentLimit: CardFlagInstallmentLimit @hasOne
+  interestConfigurations: [InterestConfiguration!]! @hasMany
+  created_at: DateTimeTz!
+  updated_at: DateTimeTz!
+}
+
+type CardFlagInstallmentLimit @model(class: "App\\Models\\Api\\V1\\CardFlagInstallmentLimit") {
+  id: ID!
+  card_flag_id: Int!
+  installments: Int!
+  min_value: Float!
+  cardFlag: CardFlag @belongsTo
+  created_at: DateTimeTz!
+  updated_at: DateTimeTz!
+}
+
+extend type Query {
+  cardFlag(id: ID! @eq): CardFlag @find
+  cardFlags(page: Int, name: String @where(operator: "like")): [CardFlag!]! @paginate(defaultCount: 10)
+  cardFlagInstallmentLimit(id: ID! @eq): CardFlagInstallmentLimit @find
+  cardFlagInstallmentLimits(page: Int): [CardFlagInstallmentLimit!]! @paginate(defaultCount: 10)
+}
+
+extend type Mutation {
+  createCardFlag(input: CreateCardFlagInput! @spread): CardFlag! @create(model: "App\\Models\\Api\\V1\\CardFlag")
+  updateCardFlag(input: UpdateCardFlagInput! @spread): CardFlag! @update(model: "App\\Models\\Api\\V1\\CardFlag")
+  deleteCardFlag(id: ID! @whereKey): CardFlag! @delete(model: "App\\Models\\Api\\V1\\CardFlag")
+
+  createCardFlagInstallmentLimit(input: CreateCardFlagInstallmentLimitInput! @spread): CardFlagInstallmentLimit! @create(model: "App\\Models\\Api\\V1\\CardFlagInstallmentLimit")
+  updateCardFlagInstallmentLimit(input: UpdateCardFlagInstallmentLimitInput! @spread): CardFlagInstallmentLimit! @update(model: "App\\Models\\Api\\V1\\CardFlagInstallmentLimit")
+  deleteCardFlagInstallmentLimit(id: ID! @whereKey): CardFlagInstallmentLimit! @delete(model: "App\\Models\\Api\\V1\\CardFlagInstallmentLimit")
+}
+
+input CreateCardFlagInput {
+  name: String!
+  photo_path: String
+}
+
+input UpdateCardFlagInput {
+  id: ID! @whereKey
+  name: String
+  photo_path: String
+}
+
+input CreateCardFlagInstallmentLimitInput {
+  card_flag_id: Int!
+  installments: Int!
+  min_value: Float!
+}
+
+input UpdateCardFlagInstallmentLimitInput {
+  id: ID! @whereKey
+  card_flag_id: Int
+  installments: Int
+  min_value: Float
+}

--- a/graphql/client.graphql
+++ b/graphql/client.graphql
@@ -1,0 +1,75 @@
+"Client information registered in the system."
+type Client @model(class: "App\\Models\\Api\\V1\\Client") {
+  id: ID!
+  full_name: String!
+  street: String
+  neighborhood: String
+  state: String
+  zip_code: String
+  city: String
+  phone: String
+  rg: String
+  rg_front_photo_path: String
+  rg_back_photo_path: String
+  cpf: String
+  cpf_front_photo_path: String
+  cpf_back_photo_path: String
+  description: String
+  legal_representative: String
+  father_name: String
+  mother_name: String
+  created_at: DateTimeTz!
+  updated_at: DateTimeTz!
+}
+
+extend type Query {
+  client(id: ID! @eq): Client @find
+  clients(page: Int, full_name: String @where(operator: "like")): [Client!]! @paginate(defaultCount: 10)
+}
+
+extend type Mutation {
+  createClient(input: CreateClientInput! @spread): Client! @create(model: "App\\Models\\Api\\V1\\Client")
+  updateClient(input: UpdateClientInput! @spread): Client! @update(model: "App\\Models\\Api\\V1\\Client")
+  deleteClient(id: ID! @whereKey): Client! @delete(model: "App\\Models\\Api\\V1\\Client")
+}
+
+input CreateClientInput {
+  full_name: String!
+  street: String
+  neighborhood: String
+  state: String
+  zip_code: String
+  city: String
+  phone: String
+  rg: String
+  rg_front_photo_path: String
+  rg_back_photo_path: String
+  cpf: String
+  cpf_front_photo_path: String
+  cpf_back_photo_path: String
+  description: String
+  legal_representative: String
+  father_name: String
+  mother_name: String
+}
+
+input UpdateClientInput {
+  id: ID! @whereKey
+  full_name: String
+  street: String
+  neighborhood: String
+  state: String
+  zip_code: String
+  city: String
+  phone: String
+  rg: String
+  rg_front_photo_path: String
+  rg_back_photo_path: String
+  cpf: String
+  cpf_front_photo_path: String
+  cpf_back_photo_path: String
+  description: String
+  legal_representative: String
+  father_name: String
+  mother_name: String
+}

--- a/graphql/interest.graphql
+++ b/graphql/interest.graphql
@@ -1,0 +1,42 @@
+"Interest configuration rules."
+type InterestConfiguration @model(class: "App\\Models\\Api\\V1\\InterestConfiguration") {
+  id: ID!
+  card_flag_id: Int!
+  store_id: Int!
+  value_type_id: Int!
+  installments: Int!
+  interest_rate: Float!
+  cardFlag: CardFlag @belongsTo
+  store: Store @belongsTo
+  valueType: ValueType @belongsTo
+  created_at: DateTimeTz!
+  updated_at: DateTimeTz!
+}
+
+extend type Query {
+  interestConfiguration(id: ID! @eq): InterestConfiguration @find
+  interestConfigurations(page: Int): [InterestConfiguration!]! @paginate(defaultCount: 10)
+}
+
+extend type Mutation {
+  createInterestConfiguration(input: CreateInterestConfigurationInput! @spread): InterestConfiguration! @create(model: "App\\Models\\Api\\V1\\InterestConfiguration")
+  updateInterestConfiguration(input: UpdateInterestConfigurationInput! @spread): InterestConfiguration! @update(model: "App\\Models\\Api\\V1\\InterestConfiguration")
+  deleteInterestConfiguration(id: ID! @whereKey): InterestConfiguration! @delete(model: "App\\Models\\Api\\V1\\InterestConfiguration")
+}
+
+input CreateInterestConfigurationInput {
+  card_flag_id: Int!
+  store_id: Int!
+  value_type_id: Int!
+  installments: Int!
+  interest_rate: Float!
+}
+
+input UpdateInterestConfigurationInput {
+  id: ID! @whereKey
+  card_flag_id: Int
+  store_id: Int
+  value_type_id: Int
+  installments: Int
+  interest_rate: Float
+}

--- a/graphql/photo.graphql
+++ b/graphql/photo.graphql
@@ -1,0 +1,31 @@
+"Store photo file."
+type PhotoStore @model(class: "App\\Models\\Api\\V1\\PhotoStore") {
+  id: ID!
+  photo_path: String!
+  store_id: Int
+  store: Store @belongsTo
+  created_at: DateTimeTz!
+  updated_at: DateTimeTz!
+}
+
+extend type Query {
+  photoStore(id: ID! @eq): PhotoStore @find
+  photoStores(page: Int, store_id: Int): [PhotoStore!]! @paginate(defaultCount: 10)
+}
+
+extend type Mutation {
+  createPhotoStore(input: CreatePhotoStoreInput! @spread): PhotoStore! @create(model: "App\\Models\\Api\\V1\\PhotoStore")
+  updatePhotoStore(input: UpdatePhotoStoreInput! @spread): PhotoStore! @update(model: "App\\Models\\Api\\V1\\PhotoStore")
+  deletePhotoStore(id: ID! @whereKey): PhotoStore! @delete(model: "App\\Models\\Api\\V1\\PhotoStore")
+}
+
+input CreatePhotoStoreInput {
+  photo_path: String!
+  store_id: Int
+}
+
+input UpdatePhotoStoreInput {
+  id: ID! @whereKey
+  photo_path: String
+  store_id: Int
+}

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -1,1 +1,11 @@
 #import user.graphql
+#import announcement.graphql
+#import cardflag.graphql
+#import client.graphql
+#import interest.graphql
+#import photo.graphql
+#import simulation.graphql
+#import solution.graphql
+#import store.graphql
+#import testimony.graphql
+#import valuetype.graphql

--- a/graphql/simulation.graphql
+++ b/graphql/simulation.graphql
@@ -1,0 +1,60 @@
+"Loan simulation data."
+type Simulation @model(class: "App\\Models\\Api\\V1\\Simulation") {
+  id: ID!
+  uuid: String
+  amount: Float!
+  amount_with_interest: Float!
+  interest_rate_by_type_of_amount: Float!
+  interest_rate_by_number_of_installments: Float!
+  value_type_id: Int!
+  installments: Int!
+  installment_value: Float!
+  store_id: Int!
+  card_flag_id: Int!
+  ip: String
+  store: Store @belongsTo
+  cardFlag: CardFlag @belongsTo
+  valueType: ValueType @belongsTo
+  created_at: DateTimeTz!
+  updated_at: DateTimeTz!
+}
+
+extend type Query {
+  simulation(id: ID! @eq): Simulation @find
+  simulations(page: Int, store_id: Int): [Simulation!]! @paginate(defaultCount: 10)
+}
+
+extend type Mutation {
+  createSimulation(input: CreateSimulationInput! @spread): Simulation! @create(model: "App\\Models\\Api\\V1\\Simulation")
+  updateSimulation(input: UpdateSimulationInput! @spread): Simulation! @update(model: "App\\Models\\Api\\V1\\Simulation")
+  deleteSimulation(id: ID! @whereKey): Simulation! @delete(model: "App\\Models\\Api\\V1\\Simulation")
+}
+
+input CreateSimulationInput {
+  uuid: String
+  amount: Float!
+  amount_with_interest: Float!
+  interest_rate_by_type_of_amount: Float!
+  interest_rate_by_number_of_installments: Float!
+  value_type_id: Int!
+  installments: Int!
+  installment_value: Float!
+  store_id: Int!
+  card_flag_id: Int!
+  ip: String
+}
+
+input UpdateSimulationInput {
+  id: ID! @whereKey
+  uuid: String
+  amount: Float
+  amount_with_interest: Float
+  interest_rate_by_type_of_amount: Float
+  interest_rate_by_number_of_installments: Float
+  value_type_id: Int
+  installments: Int
+  installment_value: Float
+  store_id: Int
+  card_flag_id: Int
+  ip: String
+}

--- a/graphql/solution.graphql
+++ b/graphql/solution.graphql
@@ -1,0 +1,42 @@
+"Solution offered to customers."
+type Solution @model(class: "App\\Models\\Api\\V1\\Solution") {
+  id: ID!
+  title: String!
+  description: String
+  photo_path: String
+  order: Int
+  width: String
+  height: String
+  created_at: DateTimeTz!
+  updated_at: DateTimeTz!
+}
+
+extend type Query {
+  solution(id: ID! @eq): Solution @find
+  solutions(page: Int): [Solution!]! @paginate(defaultCount: 10)
+}
+
+extend type Mutation {
+  createSolution(input: CreateSolutionInput! @spread): Solution! @create(model: "App\\Models\\Api\\V1\\Solution")
+  updateSolution(input: UpdateSolutionInput! @spread): Solution! @update(model: "App\\Models\\Api\\V1\\Solution")
+  deleteSolution(id: ID! @whereKey): Solution! @delete(model: "App\\Models\\Api\\V1\\Solution")
+}
+
+input CreateSolutionInput {
+  title: String!
+  description: String
+  photo_path: String
+  order: Int
+  width: String
+  height: String
+}
+
+input UpdateSolutionInput {
+  id: ID! @whereKey
+  title: String
+  description: String
+  photo_path: String
+  order: Int
+  width: String
+  height: String
+}

--- a/graphql/store.graphql
+++ b/graphql/store.graphql
@@ -1,0 +1,74 @@
+"Store entity."
+type Store @model(class: "App\\Models\\Api\\V1\\Store") {
+  id: ID!
+  name: String!
+  address: StoreAddress @hasOne
+  photoStores: [PhotoStore!]! @hasMany
+  interestConfigurations: [InterestConfiguration!]! @hasMany
+  created_at: DateTimeTz!
+  updated_at: DateTimeTz!
+}
+
+type StoreAddress @model(class: "App\\Models\\Api\\V1\\StoreAddress") {
+  id: ID!
+  uf: String!
+  city: String!
+  neighborhood: String!
+  zip_code: String!
+  street: String!
+  number: Int!
+  coordinates: String
+  store_id: Int
+  store: Store @belongsTo
+  created_at: DateTimeTz!
+  updated_at: DateTimeTz!
+}
+
+extend type Query {
+  store(id: ID! @eq): Store @find
+  stores(page: Int, name: String @where(operator: "like")): [Store!]! @paginate(defaultCount: 10)
+  storeAddress(id: ID! @eq): StoreAddress @find
+  storeAddresses(page: Int, city: String @where(operator: "like")): [StoreAddress!]! @paginate(defaultCount: 10)
+}
+
+extend type Mutation {
+  createStore(input: CreateStoreInput! @spread): Store! @create(model: "App\\Models\\Api\\V1\\Store")
+  updateStore(input: UpdateStoreInput! @spread): Store! @update(model: "App\\Models\\Api\\V1\\Store")
+  deleteStore(id: ID! @whereKey): Store! @delete(model: "App\\Models\\Api\\V1\\Store")
+
+  createStoreAddress(input: CreateStoreAddressInput! @spread): StoreAddress! @create(model: "App\\Models\\Api\\V1\\StoreAddress")
+  updateStoreAddress(input: UpdateStoreAddressInput! @spread): StoreAddress! @update(model: "App\\Models\\Api\\V1\\StoreAddress")
+  deleteStoreAddress(id: ID! @whereKey): StoreAddress! @delete(model: "App\\Models\\Api\\V1\\StoreAddress")
+}
+
+input CreateStoreInput {
+  name: String!
+}
+
+input UpdateStoreInput {
+  id: ID! @whereKey
+  name: String
+}
+
+input CreateStoreAddressInput {
+  uf: String!
+  city: String!
+  neighborhood: String!
+  zip_code: String!
+  street: String!
+  number: Int!
+  coordinates: String
+  store_id: Int
+}
+
+input UpdateStoreAddressInput {
+  id: ID! @whereKey
+  uf: String
+  city: String
+  neighborhood: String
+  zip_code: String
+  street: String
+  number: Int
+  coordinates: String
+  store_id: Int
+}

--- a/graphql/testimony.graphql
+++ b/graphql/testimony.graphql
@@ -1,0 +1,45 @@
+"Customer testimony."
+type Testimony @model(class: "App\\Models\\Api\\V1\\Testimony") {
+  id: ID!
+  name: String!
+  surname: String!
+  city: String!
+  uf: String!
+  photo_path: String
+  message: String
+  status: Boolean!
+  created_at: DateTimeTz!
+  updated_at: DateTimeTz!
+}
+
+extend type Query {
+  testimony(id: ID! @eq): Testimony @find
+  testimonies(page: Int, status: Boolean): [Testimony!]! @paginate(defaultCount: 10)
+}
+
+extend type Mutation {
+  createTestimony(input: CreateTestimonyInput! @spread): Testimony! @create(model: "App\\Models\\Api\\V1\\Testimony")
+  updateTestimony(input: UpdateTestimonyInput! @spread): Testimony! @update(model: "App\\Models\\Api\\V1\\Testimony")
+  deleteTestimony(id: ID! @whereKey): Testimony! @delete(model: "App\\Models\\Api\\V1\\Testimony")
+}
+
+input CreateTestimonyInput {
+  name: String!
+  surname: String!
+  city: String!
+  uf: String!
+  photo_path: String
+  message: String
+  status: Boolean = true
+}
+
+input UpdateTestimonyInput {
+  id: ID! @whereKey
+  name: String
+  surname: String
+  city: String
+  uf: String
+  photo_path: String
+  message: String
+  status: Boolean
+}

--- a/graphql/valuetype.graphql
+++ b/graphql/valuetype.graphql
@@ -1,0 +1,33 @@
+"Value type configuration."
+type ValueType @model(class: "App\\Models\\Api\\V1\\ValueType") {
+  id: ID!
+  type: String!
+  interest_rate: Float
+  direction: String
+  created_at: DateTimeTz!
+  updated_at: DateTimeTz!
+}
+
+extend type Query {
+  valueType(id: ID! @eq): ValueType @find
+  valueTypes(page: Int): [ValueType!]! @paginate(defaultCount: 10)
+}
+
+extend type Mutation {
+  createValueType(input: CreateValueTypeInput! @spread): ValueType! @create(model: "App\\Models\\Api\\V1\\ValueType")
+  updateValueType(input: UpdateValueTypeInput! @spread): ValueType! @update(model: "App\\Models\\Api\\V1\\ValueType")
+  deleteValueType(id: ID! @whereKey): ValueType! @delete(model: "App\\Models\\Api\\V1\\ValueType")
+}
+
+input CreateValueTypeInput {
+  type: String!
+  interest_rate: Float
+  direction: String
+}
+
+input UpdateValueTypeInput {
+  id: ID! @whereKey
+  type: String
+  interest_rate: Float
+  direction: String
+}


### PR DESCRIPTION
## Descrição
- Criação de schemas GraphQL para todos os modelos da aplicação
- Atualização do `schema.graphql` para importar os novos arquivos

## Testes
- `composer test` *(falhou: comando não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_6864655cdeb8832990e1d1b057d3ebc1