### PR TITLE
Add initial frontend components

### DIFF
--- a/auth-lend-front/package-lock.json
+++ b/auth-lend-front/package-lock.json
@@ -8,6 +8,8 @@
       "name": "auth-lend-front",
       "version": "0.1.0",
       "dependencies": {
+        "keen-slider": "^6.8.6",
+        "lucide-react": "^0.525.0",
         "next": "15.3.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -4180,6 +4182,12 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/keen-slider": {
+      "version": "6.8.6",
+      "resolved": "https://registry.npmjs.org/keen-slider/-/keen-slider-6.8.6.tgz",
+      "integrity": "sha512-dcEQ7GDBpCjUQA8XZeWh3oBBLLmyn8aoeIQFGL/NTVkoEOsmlnXqA4QykUm/SncolAZYGsEk/PfUhLZ7mwMM2w==",
+      "license": "MIT"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4497,6 +4505,15 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.525.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.525.0.tgz",
+      "integrity": "sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/auth-lend-front/package.json
+++ b/auth-lend-front/package.json
@@ -9,19 +9,21 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "keen-slider": "^6.8.6",
+    "lucide-react": "^0.525.0",
+    "next": "15.3.4",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "next": "15.3.4"
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.3.4",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }

--- a/auth-lend-front/src/app/page.tsx
+++ b/auth-lend-front/src/app/page.tsx
@@ -1,103 +1,15 @@
-import Image from "next/image";
+import Navbar from "../components/Navbar";
+import HeroCarousel from "../components/HeroCarousel";
+import SolutionsCarousel from "../components/SolutionsCarousel";
 
 export default function Home() {
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="list-inside list-decimal text-sm/6 text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-[family-name:var(--font-geist-mono)] font-semibold">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
+    <>
+      <Navbar />
+      <main>
+        <HeroCarousel />
+        <SolutionsCarousel />
       </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
+    </>
   );
 }

--- a/auth-lend-front/src/components/HeroCarousel.tsx
+++ b/auth-lend-front/src/components/HeroCarousel.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import Image from "next/image";
+import { useKeenSlider } from "keen-slider/react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+interface Slide {
+  title: string;
+  subtitle: string;
+  description: string;
+  subDescription: string;
+  image: string;
+}
+
+const slides: Slide[] = [
+  {
+    title: "Bem-vindo",
+    subtitle: "Soluções de crédito",
+    description: "Facilidade e rapidez para você",
+    subDescription: "Confira nossas opções",
+    image: "https://picsum.photos/id/1018/1000/600",
+  },
+  {
+    title: "Atendimento Especial",
+    subtitle: "Suporte dedicado",
+    description: "Fale com especialistas quando precisar",
+    subDescription: "Estamos prontos para ajudar",
+    image: "https://picsum.photos/id/1015/1000/600",
+  },
+  {
+    title: "Segurança",
+    subtitle: "Seus dados protegidos",
+    description: "Tecnologia e privacidade",
+    subDescription: "Conte conosco",
+    image: "https://picsum.photos/id/1016/1000/600",
+  },
+  {
+    title: "Transparência",
+    subtitle: "Informações claras",
+    description: "Tudo detalhado para você",
+    subDescription: "Sem surpresas",
+    image: "https://picsum.photos/id/1021/1000/600",
+  },
+  {
+    title: "Praticidade",
+    subtitle: "Processos simplificados",
+    description: "Agilidade no seu dia a dia",
+    subDescription: "Solicite já",
+    image: "https://picsum.photos/id/1020/1000/600",
+  },
+  {
+    title: "Confiabilidade",
+    subtitle: "Anos de experiência",
+    description: "Tradição no mercado",
+    subDescription: "Faça parte",
+    image: "https://picsum.photos/id/1024/1000/600",
+  },
+];
+
+export default function HeroCarousel() {
+  const [sliderRef, instanceRef] = useKeenSlider<HTMLDivElement>({
+    loop: true,
+    renderMode: "performance",
+    slides: { perView: 1 },
+  });
+
+  return (
+    <section className="relative">
+      <div ref={sliderRef} className="keen-slider">
+        {slides.map((slide, idx) => (
+          <div key={idx} className="keen-slider__slide">
+            {/* Desktop layout */}
+            <div className="hidden md:grid grid-cols-2 h-80 md:h-[32rem]">
+              <div className="flex flex-col justify-center gap-4 p-8 md:p-12">
+                <h2 className="text-3xl font-bold">{slide.title}</h2>
+                <h3 className="text-xl font-semibold text-gray-600 dark:text-gray-300">
+                  {slide.subtitle}
+                </h3>
+                <p className="text-gray-700 dark:text-gray-200">{slide.description}</p>
+                <p className="text-gray-700 dark:text-gray-200">
+                  {slide.subDescription}
+                </p>
+                <button className="w-max px-4 py-2 bg-blue-600 text-white rounded-md">
+                  Saiba mais
+                </button>
+              </div>
+              <div className="relative">
+                <Image src={slide.image} alt="slide" fill className="object-cover" />
+              </div>
+            </div>
+            {/* Mobile layout */}
+            <div className="md:hidden relative h-80">
+              <Image src={slide.image} alt="slide" fill className="object-cover" />
+              <div className="absolute inset-0 bg-black/50 flex flex-col justify-end p-4 gap-2 text-white">
+                <h2 className="text-2xl font-bold">{slide.title}</h2>
+                <h3 className="text-lg font-semibold">{slide.subtitle}</h3>
+                <p>{slide.description}</p>
+                <p>{slide.subDescription}</p>
+                <button className="mt-2 w-max px-4 py-2 bg-blue-600 text-white rounded-md">
+                  Saiba mais
+                </button>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="absolute inset-0 flex items-center justify-between pointer-events-none">
+        <button
+          aria-label="Previous slide"
+          onClick={() => instanceRef.current?.prev()}
+          className="pointer-events-auto ml-4 p-2 bg-white/70 rounded-full shadow hover:bg-white"
+        >
+          <ChevronLeft className="w-5 h-5" />
+        </button>
+        <button
+          aria-label="Next slide"
+          onClick={() => instanceRef.current?.next()}
+          className="pointer-events-auto mr-4 p-2 bg-white/70 rounded-full shadow hover:bg-white"
+        >
+          <ChevronRight className="w-5 h-5" />
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/auth-lend-front/src/components/Navbar.tsx
+++ b/auth-lend-front/src/components/Navbar.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import Link from "next/link";
+
+export default function Navbar() {
+  return (
+    <header className="shadow-sm sticky top-0 z-50 bg-white/80 backdrop-blur-md dark:bg-gray-900/80">
+      <nav className="container mx-auto px-4 flex h-14 items-center justify-between">
+        <Link href="/" className="text-lg font-semibold">AuthLend</Link>
+        <div />
+      </nav>
+    </header>
+  );
+}

--- a/auth-lend-front/src/components/SolutionsCarousel.tsx
+++ b/auth-lend-front/src/components/SolutionsCarousel.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useKeenSlider } from "keen-slider/react";
+import "keen-slider/keen-slider.min.css";
+import { Briefcase } from "lucide-react";
+
+interface Solution {
+  id: number;
+  title: string;
+  description: string;
+}
+
+export default function SolutionsCarousel() {
+  const [solutions, setSolutions] = useState<Solution[]>([]);
+  const [sliderRef, instanceRef] = useKeenSlider<HTMLDivElement>({
+    loop: false,
+    slides: { perView: 2, spacing: 16 },
+    breakpoints: {
+      "(min-width: 768px)": { slides: { perView: 4, spacing: 16 } },
+      "(min-width: 1280px)": { slides: { perView: 8, spacing: 16 } },
+    },
+    renderMode: "performance",
+  });
+
+  useEffect(() => {
+    fetch("/api/v1/solutions?per_page=20")
+      .then((res) => res.json())
+      .then((data) => {
+        const list = data?.data?.data ?? [];
+        setSolutions(list);
+      })
+      .catch(() => {});
+  }, []);
+
+  return (
+    <section className="py-12">
+      <h2 className="text-center text-2xl font-bold mb-8">Nossas soluções</h2>
+      <div className="relative">
+        <div ref={sliderRef} className="keen-slider">
+          {solutions.map((sol) => (
+            <div key={sol.id} className="keen-slider__slide">
+              <div className="h-40 w-full bg-white dark:bg-gray-800 border rounded flex flex-col items-center justify-center p-4">
+                <Briefcase className="w-6 h-6 mb-2" />
+                <h3 className="font-semibold text-center mb-1 text-sm">
+                  {sol.title}
+                </h3>
+                <p className="text-xs text-center text-gray-600 dark:text-gray-400">
+                  {sol.description}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="absolute inset-0 flex items-center justify-between pointer-events-none">
+          <button
+            aria-label="Anterior"
+            onClick={() => instanceRef.current?.prev()}
+            className="pointer-events-auto ml-2 p-1 bg-white/70 rounded-full shadow hover:bg-white"
+          >
+            <span className="sr-only">Anterior</span>
+            &#8249;
+          </button>
+          <button
+            aria-label="Próximo"
+            onClick={() => instanceRef.current?.next()}
+            className="pointer-events-auto mr-2 p-1 bg-white/70 rounded-full shadow hover:bg-white"
+          >
+            <span className="sr-only">Próximo</span>
+            &#8250;
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/auth-lend-front/tailwind.config.ts
+++ b/auth-lend-front/tailwind.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- install lucide-react and keen-slider for icons and carousels
- configure Tailwind CSS
- add navigation bar
- add hero carousel with images and responsive layout
- fetch solutions from backend and show them in a carousel

## Testing
- `npm run lint`
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866a6f210e08329a677af0029d81279